### PR TITLE
Add panel transition test

### DIFF
--- a/performance/tests/PanelTransition.test.js
+++ b/performance/tests/PanelTransition.test.js
@@ -1,0 +1,47 @@
+const puppeteer = require('puppeteer');
+const {getFileName} = require('../utils');
+
+describe('Panel Transition', () => {
+	let browser, page;
+
+	beforeEach(async () => {
+		browser = await puppeteer.launch({headless: true});
+		page = await browser.newPage();
+		await page.setViewport({
+			width: 1920,
+			height: 1080
+		});
+
+		const client = await page.target().createCDPSession();
+		await client.send('Emulation.setCPUThrottlingRate', {rate: 6});
+	});
+
+	afterEach(async () => {
+		await browser.close();
+	});
+
+	it('should transition under threshold with ExpandableList children', async () => {
+		const filename = getFileName('PanelTransition');
+		const item = '[class^="Item_item"]';
+
+		await page.goto('http://localhost:8080/panelTransition');
+		await page.tracing.start({path: filename, screenshots: true});
+		await page.waitForSelector('#el_10_9');
+
+		await page.click(item);
+		await page.waitForSelector('#el_20_19');
+
+		await page.click(item);
+		await page.waitForSelector('#el_30_29');
+
+		await page.click(item);
+		await page.waitForSelector('#el_40_39');
+
+		await page.click(item);
+		await page.waitForSelector('#el_50_49');
+
+		await page.tracing.stop();
+		await browser.close();
+	});
+});
+

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -14,6 +14,7 @@ import GridListImageItem from '../views/GridListImageItem';
 import Item from '../views/Item';
 import Slider from '../views/Slider';
 import ViewManager from '../views/ViewManager';
+import PanelTransition from '../views/PanelTransition';
 
 import css from './App.less';
 
@@ -43,6 +44,7 @@ const App = kind({
 				<Route path="/item" component={Item} />
 				<Route path="/slider" component={Slider} />
 				<Route path="/viewManager" component={ViewManager} />
+				<Route path="/panelTransition" component={PanelTransition} />
 			</div>
 		</Router>
 	)

--- a/src/views/PanelTransition.js
+++ b/src/views/PanelTransition.js
@@ -1,0 +1,74 @@
+import {ActivityPanels, Panel, Header} from '@enact/moonstone/Panels';
+import Button from '@enact/moonstone/Button';
+import ExpandableList from '@enact/moonstone/ExpandableList';
+import Item from '@enact/moonstone/Item';
+import Scroller from '@enact/moonstone/Scroller';
+import React from 'react';
+
+const createList = childrenLength => {
+	const arr = [];
+	for (let i = 0; i < childrenLength; i++) {
+		// TODO: we may be able to import components dynamically
+		arr.push(
+			<ExpandableList
+				key={`el_${childrenLength}_${i}`}
+				id={`el_${childrenLength}_${i}`}
+				title={`ExpandableList_${childrenLength}_${i}`}
+			>
+				{[
+					'expandableitem 1',
+					'expandableitem 2',
+					'expandableitem 3',
+					'expandableitem 4',
+					'expandableitem 5'
+				]}
+			</ExpandableList>
+		);
+	}
+	return arr;
+};
+
+const ScrollerPanel = ({childrenLength, onClick, ...rest}) => {
+	return (
+		<Panel {...rest}>
+			<Header title={`Title ${childrenLength}`}>
+				<Button>Button</Button>
+			</Header>
+			<Scroller>
+				<Item onClick={onClick}>Item</Item>
+				{createList(childrenLength)}
+			</Scroller>
+		</Panel>
+	);
+};
+
+class Panels extends React.Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			index: 0
+		};
+	}
+
+	handleClick = () =>
+		this.setState(state => {
+			if (state.index < 4) {
+				return {index: state.index + 1};
+			}
+			return {index: 0};
+		});
+
+	render () {
+		return (
+			<ActivityPanels index={this.state.index}>
+				<ScrollerPanel childrenLength={10} onClick={this.handleClick} />
+				<ScrollerPanel childrenLength={20} onClick={this.handleClick} />
+				<ScrollerPanel childrenLength={30} onClick={this.handleClick} />
+				<ScrollerPanel childrenLength={40} onClick={this.handleClick} />
+				<ScrollerPanel childrenLength={50} onClick={this.handleClick} />
+			</ActivityPanels>
+		);
+	}
+}
+
+export default Panels;


### PR DESCRIPTION
**This is still WIP**

Complex Panels transition measurement performance test.

A single type of children can be rendered in increment number in each panel. The timeline should tell us whether the total transition time is under the threshold whatever the type of the children is.

### Additional Consideration
- Should add a panel with `VirtualList` instead of `Scroller` to represent a real use case
- Measurement of average FPS for each transition can be misleading as the transition is a simple CSS transition and mount is delayed until the end of the transition. Need some thinking about this.
- I'm not sure how much we want to make the sample test to be "configurable".

