### PR TITLE
PLAT-64255: Add tests for multiple items in ExpandableItem

### DIFF
--- a/performance/tests/ExpandableItem.test.js
+++ b/performance/tests/ExpandableItem.test.js
@@ -55,8 +55,72 @@ describe('ExpandableItem', () => {
 		await page.tracing.stop();
 		await browser.close();
 
-		const actualMount = Mount(filename, 'Toggleable');
+		const actualMount = Mount(filename, 'Toggleable') + Update(filename, 'Transition');
 		TestResults.addResult({component: 'ExpandableItem', type: 'Mount', actualValue: actualMount});
+	});
+
+	describe('ExpandableItem with Items', () => {
+		const counts = [10, 40, 70, 100];
+
+		for (let index = 0; index < counts.length; index++) {
+			const count = counts[index];
+			it(`mounts ${count} Item components`, async () => {
+				const filename = getFileName('ExpandableItem');
+
+				const browser = await puppeteer.launch({headless: true});
+				const page = await browser.newPage();
+				await page.setViewport({
+					width: 1920,
+					height: 1080
+				});
+
+				await page.tracing.start({path: filename, screenshots: false});
+				await page.goto(`http://localhost:8080/expandableItemItems?count=${count}`);
+				await page.waitForSelector('#ExpandableItem');
+				await page.waitFor(500);
+
+				await page.tracing.stop();
+				await browser.close();
+
+				const actualMount = Mount(filename, 'ExpandableItemItems') + Update(filename, 'Transition');
+				TestResults.addResult({component: 'ExpandableItem', type: 'Mount', actualValue: actualMount});
+			});
+		}
+
+		for (let index = 0; index < counts.length; index++) {
+			const count = counts[index];
+			it(`toggles while containing ${count} Item components`, async () => {
+				const filename = getFileName('ExpandableItem');
+				const openClose = '[class^="ExpandableItem_expandableItem"]';
+
+				const browser = await puppeteer.launch({headless: true});
+				const page = await browser.newPage();
+				await page.setViewport({
+					width: 1920,
+					height: 1080
+				});
+
+				await page.tracing.start({path: filename, screenshots: false});
+				await page.goto(`http://localhost:8080/expandableItemItems?count=${count}`);
+				await page.waitForSelector('#ExpandableItem');
+
+				await page.waitFor(500);
+				await page.click(openClose);
+				await page.waitFor(200);
+				await page.click(openClose);
+				await page.waitFor(200);
+				await page.click(openClose);
+				await page.waitFor(200);
+				await page.click(openClose);
+				await page.waitFor(200);
+
+				await page.tracing.stop();
+				await browser.close();
+
+				const actualFPS = FPS(filename);
+				TestResults.addResult({component: 'ExpandableItem', type: 'Frames Per Second', actualValue: actualFPS});
+			});
+		}
 	});
 });
 

--- a/performance/tests/ExpandableItem.test.js
+++ b/performance/tests/ExpandableItem.test.js
@@ -55,6 +55,7 @@ describe('ExpandableItem', () => {
 		await page.tracing.stop();
 		await browser.close();
 
+		// Transition causes a cascading update that mounts the Expandable's children
 		const actualMount = Mount(filename, 'Toggleable') + Update(filename, 'Transition');
 		TestResults.addResult({component: 'ExpandableItem', type: 'Mount', actualValue: actualMount});
 	});
@@ -82,6 +83,7 @@ describe('ExpandableItem', () => {
 				await page.tracing.stop();
 				await browser.close();
 
+				// Transition causes a cascading update that mounts the Expandable's children
 				const actualMount = Mount(filename, 'ExpandableItemItems') + Update(filename, 'Transition');
 				TestResults.addResult({component: 'ExpandableItem', type: 'Mount', actualValue: actualMount});
 			});

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -5,6 +5,7 @@ import Picker from '../views/Picker';
 import ScrollerPanel from '../views/ScrollerPanel';
 import Panels from '../views/Panels';
 import ExpandableItem from '../views/ExpandableItem';
+import ExpandableItemItems from '../views/ExpandableItemItems';
 import Popup from '../views/Popup';
 import Marquee from '../views/Marquee';
 import Spinner from '../views/Spinner';
@@ -35,6 +36,7 @@ const App = kind({
 				<Route path="/picker" component={Picker} />
 				<Route path="/scroller" component={ScrollerPanel} />
 				<Route path="/expandableItem" component={ExpandableItem} />
+				<Route path="/expandableItemItems" component={ExpandableItemItems} />
 				<Route path="/popup" component={Popup} />
 				<Route path="/marquee" component={Marquee} />
 				<Route path="/spinner" component={Spinner} />

--- a/src/views/ExpandableItemItems.js
+++ b/src/views/ExpandableItemItems.js
@@ -1,0 +1,33 @@
+import kind from '@enact/core/kind';
+import ExpandableItem from '@enact/moonstone/ExpandableItem';
+import Item from '@enact/moonstone/Item';
+import React from 'react';
+import qs from 'qs';
+
+const ExpandableItemItems = kind({
+	name: 'ExpandableItemItems',
+
+	render: ({location}) => {
+		const arr = [];
+		const search = qs.parse(location.search, {ignoreQueryPrefix: true});
+		const count = parseInt(search.count);
+
+		for (let i = 0; i < count; i++) {
+			arr.push(
+				<Item
+					key={i}
+				>
+					{`Item ${i}`}
+				</Item>
+			);
+		}
+
+		return (
+			<ExpandableItem id="ExpandableItem" title="title" label="label">
+				{arr}
+			</ExpandableItem>
+		);
+	}
+});
+
+export default ExpandableItemItems;


### PR DESCRIPTION
We need to test mount and fps performance when using an `ExpandableItem` that contains multiple items. The more items added, the worse performance results we see. This helps identify optimizations that could be made when mounting a closed expandable (default).

Things are compounded when we use an expandable within a scroller/panel, as they can transition/animate, which could be impacted by the expandable (and vice versa).