### PR TITLE
Set default browser context to incognito mode

### DIFF
--- a/puppeteer.setup.js
+++ b/puppeteer.setup.js
@@ -3,7 +3,7 @@ const puppeteer = require('puppeteer');
 let browser, context;
 
 global.beforeAll(async () => {
-	browser = await puppeteer.launch({headless: false});
+	browser = await puppeteer.launch();
 	context = await browser.createIncognitoBrowserContext();
 });
 

--- a/puppeteer.setup.js
+++ b/puppeteer.setup.js
@@ -1,13 +1,14 @@
 const puppeteer = require('puppeteer');
 
-let browser;
+let browser, context;
 
 global.beforeAll(async () => {
-	browser = await puppeteer.launch();
+	browser = await puppeteer.launch({headless: false});
+	context = await browser.createIncognitoBrowserContext();
 });
 
 global.beforeEach(async () => {
-	const newPage = await browser.newPage();
+	const newPage = await context.newPage();
 
 	await newPage.setViewport({
 		width: 1920,
@@ -24,5 +25,6 @@ global.afterEach(async () => {
 });
 
 global.afterAll(async () => {
+	await context.close();
 	await browser.close();
 });


### PR DESCRIPTION
Set default browser context to incognito mode so that each tab do not share any data. It still calls `page.close()` in `afterEach()`, but being extra careful.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>