### PR TITLE
PLAT-75963: Add test for CSS animation vs rAF

### DIFF
--- a/performance/tests/Spinner.test.js
+++ b/performance/tests/Spinner.test.js
@@ -2,7 +2,7 @@ const {FPS, Mount} = require('../TraceModel');
 const {getFileName} = require('../utils');
 const TestResults = require('../TestResults');
 
-describe( 'Spinner', () => {
+describe('Spinner', () => {
 	it('mount', async () => {
 		const filename = getFileName('Spinner');
 

--- a/performance/tests/TransitionVsCSSAnimation.test.js
+++ b/performance/tests/TransitionVsCSSAnimation.test.js
@@ -1,0 +1,17 @@
+const {getFileName} = require('../utils');
+
+describe('TransitionVsCSSAnimation', () => {
+	it('FPS', async () => {
+		const filename = getFileName('TransitionVsCSSAnimation');
+
+		await page.goto('http://localhost:8080/transitionVsCSSAnimation');
+		await page.waitForSelector('#container');
+		await page.tracing.start({path: filename, screenshots: false});
+		await page.waitForSelector('#spinner');
+		await page.waitFor(2000);
+
+		await page.tracing.stop();
+
+		// TODO: measure FPS for each component instead of the entire timeline
+	});
+});

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -17,6 +17,7 @@ import Slider from '../views/Slider';
 import MarqueeMultiple from '../views/MarqueeMultiple';
 import ViewManager from '../views/ViewManager';
 import ScrollerMultipleChildren from '../views/ScrollerMultipleChildren';
+import TransitionVsCSSAnimation from '../views/TransitionVsCSSAnimation';
 
 import css from './App.less';
 
@@ -49,6 +50,7 @@ const App = kind({
 				<Route path="/marqueeMultiple" component={MarqueeMultiple} />
 				<Route path="/viewManager" component={ViewManager} />
 				<Route path="/scrollerMultipleChildren" component={ScrollerMultipleChildren} />
+				<Route path="/transitionVsCSSAnimation" component={TransitionVsCSSAnimation} />
 			</div>
 		</Router>
 	)

--- a/src/views/TransitionVsCSSAnimation.js
+++ b/src/views/TransitionVsCSSAnimation.js
@@ -1,0 +1,48 @@
+import React, {useState} from 'react';
+import Spinner from '@enact/moonstone/Spinner';
+import ViewManager, {SlideLeftArranger} from '@enact/ui/ViewManager';
+
+const lorem =
+	'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+const runCPUThread = () => setTimeout(() => {
+	let str;
+	for (let i = 0; i < 100000; ++i) {
+		str = str + ' ' + i;
+	}
+	runCPUThread();
+}, 0);
+
+runCPUThread();
+
+const TransitionVsCSSAnimation = () => {
+	const [index, setIndex] = useState(0);
+
+	return (
+		<div id="container" style={{display: 'flex'}} className="enact-fit">
+			{index < 5 ?
+				<ViewManager
+					id="viewManager"
+					arranger={SlideLeftArranger}
+					style={{
+						position: 'relative',
+						width: '100%',
+						overflow: 'hidden'
+					}}
+					index={index}
+					// eslint-disable-next-line react/jsx-no-bind
+					onTransition={() => setTimeout(() => setIndex(index + 1), 300)}
+				>
+					<div className="enact-fit">{lorem}</div>
+					<div className="enact-fit">{lorem}</div>
+					<div className="enact-fit">{lorem}</div>
+					<div className="enact-fit">{lorem}</div>
+					<div className="enact-fit">{lorem}</div>
+				</ViewManager> :
+				<Spinner id="spinner" />
+			}
+		</div>
+	);
+};
+
+export default TransitionVsCSSAnimation;


### PR DESCRIPTION
Add perf test for `ViewManager`'s transition performance. `Spinner` is added as part of the test for comparing CSS animation vs. rAF.

It will record the first 5 transitions of `ViewManger`, and swap with `Spinner` and wait for a couple of seconds. To mimic high CPU resource usage, the test runs long `for` loop on every event loop.

Consideration: The for loop task could be abstracted out to be utility and manage job id to correctly clearTimeout at the end of the test, but I'll leave it as is for now. One of the benefits having in a view is to observe a visible example to the test runner.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>