### PR TITLE
Fix endDate to show today's results right away

### DIFF
--- a/performanceMetrics/src/App/App.js
+++ b/performanceMetrics/src/App/App.js
@@ -180,7 +180,7 @@ const App = (props) => {
 		if (listOfTestDates.length > 0) {
 			setStartDate(convertBuildDateStringToMilis(listOfTestDates[0]));
 			// include all entries from the latest date, regardless of their hour/minute/second
-			setEndDate(convertBuildDateStringToMilis(listOfTestDates[listOfTestDates.length - 1]) + (1000 * 60 * 60 * 24));
+			setEndDate(new Date().getTime() + (1000 * 60 * 60 * 24));
 		}
 	}, [listOfTestDates]);
 


### PR DESCRIPTION
I found a bugs while checking the graph on the server page after version just  released.
The released data not displayed immediately. it was displayed after changing the enddate. (after any onEndDateSelect was invoekd)

I think this is because "-9" 
```
// setting the hour to -9 hours prior because the filename contains timestamp in KST
return new Date(year, month - 1, day, hour - 9, 0, 0).getTime();
```

I had thought of removing "-9" this. But Instead, I modified "setEndDate" part because it would be more correct to setEndDate to the current time.

Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)