### PR TITLE
WRP-12775: PerformanceMetrics refactoring and bug fixes

### DIFF
--- a/performanceMetrics/src/App/App.js
+++ b/performanceMetrics/src/App/App.js
@@ -7,7 +7,7 @@ import TabLayout, {Tab} from '@enact/sandstone/TabLayout';
 import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import Layout, {Cell} from '@enact/ui/Layout';
 import classnames from 'classnames';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import Chart from '../views/Chart';
 
@@ -62,13 +62,7 @@ const listOfComponents = [
 
 const App = (props) => {
 	const [componentReleasedData, setComponentReleasedData] = useState([]);
-	const componentReleasedDataRef = useRef([]);
-	componentReleasedDataRef.current = componentReleasedData;
-
 	const [componentDevelopData, setComponentDevelopData] = useState([]);
-	const componentDevelopDataRef = useRef([]);
-	componentDevelopDataRef.current = componentDevelopData;
-
 	const [selectedComponent, setSelectedComponent] = useState(listOfComponents[0]);
 	const [listOfMetrics, setListOfMetrics] = useState([]);
 	const [listOfVersions, setListOfVersions] = useState([]);
@@ -140,7 +134,7 @@ const App = (props) => {
 			}
 
 			setComponentReleasedData(componentMetrics);
-			setListOfMetrics([...new Set(componentReleasedDataRef.current.map(item => item.type))]);
+			setListOfMetrics([...new Set(componentMetrics.map(item => item.type))]);
 		});
 	}, [listOfVersions, selectedComponent]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/performanceMetrics/src/App/App.js
+++ b/performanceMetrics/src/App/App.js
@@ -87,14 +87,11 @@ const App = (props) => {
 		return year + '-' + month + '-' + day;
 	};
 
-	const convertBuildDateStringToMilis = (string) => {
-		let year = string.slice(8, 12);
-		let month = string.slice(12, 14);
-		let day = string.slice(14, 16);
-		let hour = string.slice(16, 18);
+	const getDefaultStartDate = () => {
+		let date = new Date();
+		date.setMonth(date.getMonth() - 1);
 
-		// setting the hour to -9 hours prior because the filename contains timestamp in KST
-		return new Date(year, month - 1, day, hour - 9, 0, 0).getTime();
+		return date.getTime() - (9 * 60 * 60 * 1000);
 	};
 
 	useEffect (() => {
@@ -177,9 +174,8 @@ const App = (props) => {
 
 	useEffect(() => {
 		if (listOfTestDates.length > 0) {
-			setStartDate(convertBuildDateStringToMilis(listOfTestDates[0]));
-			// include all entries from the latest date, regardless of their hour/minute/second
-			setEndDate(new Date().getTime() + (1000 * 60 * 60 * 24));
+			setStartDate(getDefaultStartDate());
+			setEndDate(Date.now());
 		}
 	}, [listOfTestDates]);
 
@@ -197,13 +193,6 @@ const App = (props) => {
 	const onEndDateSelect = useCallback(({value}) => {
 		setEndDate(new Date(value).getTime());
 	}, []);
-
-	const getDefaultDate = () => {
-		let date = new Date();
-		date.setMonth(date.getMonth() - 1);
-
-		return date;
-	};
 
 	return (
 		<div {...props} className={classnames(props.className, css.app)}>
@@ -224,10 +213,10 @@ const App = (props) => {
 					<Heading size="small" spacing="none" >Start Date:</Heading>
 					<DatePicker
 						className={css.datePicker}
-						defaultValue={getDefaultDate()}
 						noLabel
 						maxYear={new Date().getFullYear()}
 						onChange={onStartDateSelect}
+						value={new Date(startDate)}
 					/>
 				</Cell>
 				<Cell shrink>
@@ -237,6 +226,7 @@ const App = (props) => {
 						noLabel
 						maxYear={new Date().getFullYear()}
 						onChange={onEndDateSelect}
+						value={new Date(endDate)}
 					/>
 				</Cell>
 			</Layout>

--- a/performanceMetrics/src/index.js
+++ b/performanceMetrics/src/index.js
@@ -1,11 +1,14 @@
-import {render} from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import App from './App';
 
 const appElement = (<App />);
 
 // In a browser environment, render instead of exporting
 if (typeof window !== 'undefined') {
-	render(appElement, document.getElementById('root'));
+	const container = document.getElementById('root');
+	const root = createRoot(container);
+
+	root.render(appElement);
 }
 
 export default appElement;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
PerformanceMetrics app needs some refactoring:
- replace render with `createRoot`;
- remove redundant refs;
- apply filter by date on render; currently the filter applies only when one of the dates (start date/end date) is modified.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- migrated `index.js` file to React18 syntax;
- removed redundant refs (`componentReleasedDataRef` and `componentDevelopDataRef`);
- refactored code so that start and end dates in charts correspond to the ones in pickers (at render and when changing dates).

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-12775

### Comments