### PR TITLE
WRP-13742: PerformanceMetrics - Filter data before API call

### DIFF
--- a/performanceMetrics/src/App/App.js
+++ b/performanceMetrics/src/App/App.js
@@ -88,7 +88,7 @@ const App = (props) => {
 		const day = date.slice(6, 8);
 
 		return new Date(year, month - 1, day).getTime();
-	}
+	};
 
 	const getDefaultStartDate = () => {
 		let date = new Date();

--- a/performanceMetrics/src/App/App.js
+++ b/performanceMetrics/src/App/App.js
@@ -71,7 +71,7 @@ const App = (props) => {
 	const [startDate, setStartDate] = useState();
 	const [endDate, setEndDate] = useState();
 
-	const convertDateFromMilisToYMD = (timestamp) => {
+	const convertDateFromMillisToYMD = (timestamp) => {
 		const date = new Date(timestamp);
 
 		const year = date.getFullYear();
@@ -80,6 +80,15 @@ const App = (props) => {
 
 		return year + '-' + month + '-' + day;
 	};
+
+	const getDateFromBuildDate = (buildDate) => {
+		const date = buildDate.split('-').pop();
+		const year = date.slice(0, 4);
+		const month = date.slice(4, 6);
+		const day = date.slice(6, 8);
+
+		return new Date(year, month - 1, day).getTime();
+	}
 
 	const getDefaultStartDate = () => {
 		let date = new Date();
@@ -128,7 +137,7 @@ const App = (props) => {
 				});
 
 				for (let element of resultJSON) {
-					element.date = convertDateFromMilisToYMD(element.timestamp);
+					element.date = convertDateFromMillisToYMD(element.timestamp);
 					componentMetrics.push(element);
 				}
 			}
@@ -140,9 +149,11 @@ const App = (props) => {
 
 	useEffect (() => {
 		let componentMetrics = [], promises = [];
-
 		for (let buildDate of listOfTestDates) {
-			promises.push(fetch('./develop/' + buildDate + '/' + selectedComponent + '.txt').then(result => result.text()));
+			const date = getDateFromBuildDate(buildDate);
+			if (startDate <= date && endDate >= date) {
+				promises.push(fetch('./develop/' + buildDate + '/' + selectedComponent + '.txt').then(result => result.text()));
+			}
 		}
 
 		Promise.allSettled(promises).then((results) => {
@@ -157,14 +168,14 @@ const App = (props) => {
 				});
 
 				for ( let element of resultJSON) {
-					element.date = convertDateFromMilisToYMD(element.timestamp);
+					element.date = convertDateFromMillisToYMD(element.timestamp);
 					componentMetrics.push(element);
 				}
 			}
 
 			setComponentDevelopData(componentMetrics);
 		});
-	}, [listOfTestDates, selectedComponent]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [endDate, listOfTestDates, selectedComponent, startDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect(() => {
 		if (listOfTestDates.length > 0) {
@@ -239,7 +250,6 @@ const App = (props) => {
 							)}
 						</Scroller>
 					}
-
 				</Tab>
 				<Tab title="Develop branch metrics">
 					{componentDevelopData.length === 0 ?
@@ -248,7 +258,7 @@ const App = (props) => {
 							{listOfMetrics.map((metric) =>
 								<Chart
 									key={metric}
-									inputData={componentDevelopData.filter(entry => entry.type === metric && entry.timestamp >= startDate && entry.timestamp <= endDate)}
+									inputData={componentDevelopData.filter(entry => entry.type === metric)}
 									title={metric}
 									xAxis="date"
 								/>


### PR DESCRIPTION
### Checklist 

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The app was filtering only the already downloaded data. This caused a bigger loading time of the charts over time, since the data on the server increases every day

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The metrics data for develop branch is filtered before API call


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-13742

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com