### PR TITLE
WRR-8051: Set up a web vitals test environment on the o22 device in local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-router-dom": "^6.28.0",
-				"shelljs": "^0.8.5"
+				"shelljs": "^0.8.5",
+				"web-vitals": "^4.2.4"
 			},
 			"devDependencies": {
 				"cross-env": "^7.0.3",
@@ -2975,21 +2976,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"license": "ISC"
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -7167,6 +7153,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/web-vitals": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="
 		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-router-dom": "^6.28.0",
-		"shelljs": "^0.8.5"
+		"shelljs": "^0.8.5",
+		"web-vitals": "^4.2.4"
 	},
 	"devDependencies": {
 		"cross-env": "^7.0.3",

--- a/src/App/Agate-App.js
+++ b/src/App/Agate-App.js
@@ -64,6 +64,7 @@ const AgateApp = kind({
 		<Router>
 			<div {...props}>
 				<Routes>
+					<Route path="/" element={<OverallView />} />
 					<Route path="/arcPicker" element={<ArcPicker />} />
 					<Route path="/arcSlider" element={<ArcSlider />} />
 					<Route path="/bodyText" element={<BodyText />} />
@@ -112,6 +113,9 @@ const AgateApp = kind({
 					<Route path="/windDirectionControl" element={<WindDirectionControl />} />
 				</Routes>
 			</div>
+			<div id="FCP"></div>
+			<div id="LCP"></div>
+			<div id="INP"></div>
 		</Router>
 	)
 });

--- a/src/App/Sandstone-App.js
+++ b/src/App/Sandstone-App.js
@@ -68,6 +68,7 @@ const SandstoneApp = kind({
 		<Router>
 			<div {...props}>
 				<Routes>
+					<Route path="/" element={<OverallView />} />
 					<Route path="/alert" element={<Alert />} />
 					<Route path="/button" element={<Button />} />
 					<Route path="/bodyText" element={<BodyText />} />
@@ -120,6 +121,9 @@ const SandstoneApp = kind({
 					<Route path="/wizardPanels" element={<WizardPanels />} />
 				</Routes>
 			</div>
+			<div id="FCP"></div>
+			<div id="LCP"></div>
+			<div id="INP"></div>
 		</Router>
 	)
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import {createRoot} from 'react-dom/client';
 import AgateApp from './App/Agate-App.js';
 import SandstoneApp from './App/Sandstone-App.js';
+import reportWebVitals from './reportWebVitals';
 
 let appElement;
 
@@ -21,3 +22,10 @@ if (typeof window !== 'undefined') {
 }
 
 export default appElement;
+
+reportWebVitals((value) => {
+	const vitals = document.getElementById(value.name);
+	vitals.innerHTML = value.value;
+
+	console.log(value);
+});

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,0 +1,11 @@
+const reportWebVitals = onPerfEntry => {
+    if (onPerfEntry && onPerfEntry instanceof Function) {
+      import('web-vitals').then(({ onINP, onFCP, onLCP }) => {
+        onINP(onPerfEntry);
+        onFCP(onPerfEntry);
+        onLCP(onPerfEntry);
+      });
+    }
+  };
+
+export default reportWebVitals;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Since measurements on Bee can be affected by the server environment, we will try to measure web-vitals values ​​on the board.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
HTML tags and measurement functions to attach web-vitals values ​​have been added.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
If react-router is included, the app when run in development mode and the app built in production mode are not the same. 
This needs to be resolved.

### Links
[//]: # (Related issues, references)
WRR-8051

### Comments
Enact-DCO-1.0-Signed-off-by: Hyelyn Kim (myelyn.kim@lge.com)