### PR TITLE
WRR-23385: Remove unused eslint-disable directive 'enact/prop-types'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Checklist
+
+* [ ] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
+* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
+* [ ] At least one test case is included for this feature or bug fix
+* [ ] Documentation was added or is not needed
+* [ ] This is an API breaking change
+
+### Issue Resolved / Feature Added
+[//]: # (Describe the issue resolved or feature added by this pull request)
+
+
+### Resolution
+[//]: # (Does the code work as intended?)
+[//]: # (What is the impact of this change and *why* was it made?)
+
+
+### Additional Considerations
+[//]: # (How should the change be tested?)
+[//]: # (Are there any outstanding questions?)
+[//]: # (Were any side-effects caused by the change?)
+
+
+### Links
+[//]: # (Related issues, references)
+
+
+### Comments

--- a/src/views/agate/VirtualList.js
+++ b/src/views/agate/VirtualList.js
@@ -13,7 +13,6 @@ const populateItemsArray = (dataSize) => {
 	}
 };
 
-// eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	return (
 		<Item {...rest}>

--- a/src/views/limestone/VirtualList.js
+++ b/src/views/limestone/VirtualList.js
@@ -13,7 +13,6 @@ const populateItemsArray = (dataSize) => {
 	}
 };
 
-// eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	return (
 		<Item {...rest}>

--- a/src/views/sandstone/VirtualList.js
+++ b/src/views/sandstone/VirtualList.js
@@ -13,7 +13,6 @@ const populateItemsArray = (dataSize) => {
 	}
 };
 
-// eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	return (
 		<Item {...rest}>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://ko.react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis
PropTypes were deprecated in April 2017 (v15.5.0).
However, the enact/prop-types rule still exists, so removing PropType causes a linting error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused eslint-disable directive 'enact/prop-types'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-23385

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)